### PR TITLE
20170902+0341 Stage5p1 create_channel issue

### DIFF
--- a/servermerge/servermerge.py
+++ b/servermerge/servermerge.py
@@ -1720,10 +1720,10 @@ class Servermerge:
         if check == 'passed':
 
             if stage5p is None:
-                await self._stage5p1_(ctx),
+                await self._stage5p1_(ctx)
+                server = ctx.message.server
+                statuschannel = discord.utils.get(server.channels, id=self.mservers[server.id].get("statuschannel"))
                 stage5p = self.mservers[server.id].get("stage5p")
-
-            statuschannel = discord.utils.get(server.channels, id=self.mservers[server.id].get("statuschannel"))
 
             if statuschannel is not None:
                 embedmsg.clear_fields()
@@ -1775,6 +1775,7 @@ class Servermerge:
         try:
             statuschannel = await self.bot.create_channel(server, 'servermerge', (server.default_role, everyone),
                                                           (server.me, mine))
+            await asyncio.sleep(5)
             await self.bot.move_channel(statuschannel, 0)
             self.mservers[server.id]["statuschannel"] = statuschannel.id
             self.mservers[server.id]["stage5p"] = "sublockdown"


### PR DESCRIPTION
create_channel returns before the websocket has responded that the
channel is made, causing code the needs it's to resume, which then
throws an error. Added a 5 second delay to compisate, though if it takes
longer than that errors will still be throw.